### PR TITLE
fix(build): mark Vite apps as ESM to fix config load on Node 18

### DIFF
--- a/packages/example-app/package.json
+++ b/packages/example-app/package.json
@@ -2,6 +2,7 @@
   "name": "example-app",
   "version": "0.2.0",
   "private": true,
+  "type": "module",
   "license": "Apache-2.0",
   "dependencies": {
     "@kunalabs-io/sui-snap-wallet": "workspace:*",

--- a/packages/wallet-dapp/package.json
+++ b/packages/wallet-dapp/package.json
@@ -2,6 +2,7 @@
   "name": "wallet-ui",
   "version": "0.2.0",
   "private": true,
+  "type": "module",
   "license": "Apache-2.0",
   "dependencies": {
     "@kunalabs-io/sui-snap-wallet": "workspace:*",


### PR DESCRIPTION
## Problem

The Cloudflare Pages deploy of `wallet-dapp` was failing during `vite build`:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../vite-tsconfig-paths/dist/index.js
from .../packages/wallet-dapp/vite.config.ts not supported.
```

Cloudflare's build was running on **Node 18.17.1**. On Node 18, Vite bundles `vite.config.ts` to CommonJS (because the package has no `"type": "module"`) and `require()`s it — but `vite-tsconfig-paths@5` is pure ESM, so the `require()` throws. It worked locally only because local dev is on Node 20+/22+, where `require(esm)` is supported.

## Fix

Add `"type": "module"` to the package so Vite loads `vite.config.ts` via native `import()` instead of bundle-and-`require`. This makes the build correct on **any** Node version (including 18) and uses Vite's supported, non-deprecated config-loading path.

Applied to:
- **`packages/wallet-dapp`** — the package that broke the deploy.
- **`packages/example-app`** — same latent bug (byte-for-byte identical `vite.config.ts` + `vite-tsconfig-paths@5`). It wasn't in the Cloudflare build command, but `dev`/`build` would fail identically on Node 18.

`packages/snap` is intentionally left alone: its `snap.config.ts` only does a type-only import (erased at compile, no runtime ESM `require`), and it has a CommonJS `.eslintrc.js` that `"type": "module"` would break. `wallet-adapter` is already `"type": "module"`.

Safe because the only `.js` config in each touched package is already `.eslintrc.cjs`. Both builds verified green locally.

## Note

The Cloudflare build image was also pinned to Node 22, which independently resolves the symptom. This change is the root-cause fix and keeps the build Node-version-independent as defense in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)